### PR TITLE
Here's a revised message for you:

### DIFF
--- a/install/requirements_py3.11.txt
+++ b/install/requirements_py3.11.txt
@@ -1,3 +1,4 @@
+google-cloud-spanner
 grpcio==1.53.2
 grpcio-tools==1.53.0
 qdrant-client

--- a/tests/test_spanner.py
+++ b/tests/test_spanner.py
@@ -1,0 +1,344 @@
+import unittest
+from unittest.mock import MagicMock, patch, ANY, call
+import os
+
+# Set emulator host for tests if not set, to avoid credential errors during object init
+if "SPANNER_EMULATOR_HOST" not in os.environ:
+    os.environ["SPANNER_EMULATOR_HOST"] = "localhost:9010"
+
+# Import spanner_v1 for param_types used in assertions
+from google.cloud import spanner_v1
+from vectordb_bench.backend.clients.spanner.spanner import SpannerVectorDB
+from vectordb_bench.backend.clients.spanner.config import SpannerConfig, SpannerCaseConfig
+# EmptyDBCaseConfig might not be needed if SpannerCaseConfig is always used.
+# from vectordb_bench.backend.clients.api import EmptyDBCaseConfig
+
+
+class TestSpannerCaseConfig(unittest.TestCase):
+    def test_index_param(self):
+        config = SpannerCaseConfig(num_leaves=1500, tree_depth=3, num_leaves_to_search=150)
+        expected = {"num_leaves": 1500, "tree_depth": 3}
+        self.assertEqual(config.index_param(), expected)
+
+    def test_search_param(self):
+        config = SpannerCaseConfig(num_leaves=1500, tree_depth=3, num_leaves_to_search=150)
+        expected = {"num_leaves_to_search": 150}
+        self.assertEqual(config.search_param(), expected)
+
+
+class TestSpannerVectorDB(unittest.TestCase):
+    PROJECT_ID = "test-project"
+    INSTANCE_ID = "test-instance"
+    DATABASE_ID = "test-database"
+    TABLE_NAME = "test_vector_embeddings"
+    DIMENSION = 128
+
+    def get_db_config(self):
+        return {
+            "project_id": self.PROJECT_ID,
+            "instance_id": self.INSTANCE_ID,
+            "database_id": self.DATABASE_ID,
+            "table_name": self.TABLE_NAME,
+            # "emulator_host": os.environ.get("SPANNER_EMULATOR_HOST") # Handled by SpannerVectorDB
+        }
+
+    def get_case_config(self, num_leaves=2000, num_leaves_to_search=50, tree_depth=2):
+        # Using SpannerCaseConfig directly and allowing parameterization for tests
+        return SpannerCaseConfig(
+            num_leaves=num_leaves,
+            num_leaves_to_search=num_leaves_to_search,
+            tree_depth=tree_depth
+        )
+
+    @patch('vectordb_bench.backend.clients.spanner.spanner.spanner_v1.Client')
+    def setUp(self, MockSpannerClient):
+        # Mock the Spanner client and its hierarchy
+        self.mock_client = MockSpannerClient.return_value
+        self.mock_instance = MagicMock()
+        self.mock_database = MagicMock()
+
+        self.mock_client.instance.return_value = self.mock_instance
+        self.mock_instance.database.return_value = self.mock_database
+
+        # Simulate instance and database exist by default
+        self.mock_instance.exists.return_value = True
+        self.mock_database.exists.return_value = True
+
+        # Mock DDL operations
+        self.mock_ddl_operation = MagicMock()
+        self.mock_ddl_operation.result.return_value = None # Simulate DDL completion
+        self.mock_database.update_ddl.return_value = self.mock_ddl_operation
+
+        # Mock snapshot and batch
+        self.mock_snapshot_context = MagicMock()
+        self.mock_snapshot = MagicMock()
+        self.mock_database.snapshot.return_value = self.mock_snapshot_context
+        self.mock_snapshot_context.__enter__.return_value = self.mock_snapshot
+        self.mock_snapshot_context.__exit__.return_value = None
+
+        self.mock_batch_context = MagicMock()
+        self.mock_batch = MagicMock()
+        self.mock_database.batch.return_value = self.mock_batch_context
+        self.mock_batch_context.__enter__.return_value = self.mock_batch
+        self.mock_batch_context.__exit__.return_value = None
+
+        # Default to table not existing for initial setup in most tests
+        self.mock_snapshot.execute_sql.side_effect = [iter([])] # No results for table check
+
+        # Initialize SpannerVectorDB
+        # We pass SpannerConfig directly now, not a dict
+        self.db = SpannerVectorDB(
+            dim=self.DIMENSION,
+            db_config=self.get_db_config(),
+            db_case_config=self.get_case_config(),
+            collection_name=self.TABLE_NAME, # collection_name is used as table_name by SpannerVectorDB
+            drop_old=False
+        )
+        # Reset side effect for subsequent execute_sql calls in tests
+        self.mock_snapshot.execute_sql.side_effect = None
+
+
+    @patch('vectordb_bench.backend.clients.spanner.spanner.spanner_v1.Client')
+    def test_init_emulator(self, MockSpannerClient):
+        os.environ["SPANNER_EMULATOR_HOST"] = "localhost:9010"
+        db_config_dict = self.get_db_config()
+        db_config_dict["emulator_host"] = "localhost:9010"
+
+        db = SpannerVectorDB(
+            dim=self.DIMENSION,
+            db_config=db_config_dict,
+            db_case_config=self.get_case_config(),
+            collection_name=self.TABLE_NAME,
+            drop_old=False
+        )
+        MockSpannerClient.assert_called_with(project=self.PROJECT_ID, client_options={'api_endpoint': 'localhost:9010'})
+        del os.environ["SPANNER_EMULATOR_HOST"] # clean up
+
+    @patch('vectordb_bench.backend.clients.spanner.spanner.spanner_v1.Client')
+    def test_init_no_emulator(self, MockSpannerClient):
+        if "SPANNER_EMULATOR_HOST" in os.environ: # Ensure it's not set for this test
+            del os.environ["SPANNER_EMULATOR_HOST"]
+
+        db_config_dict = self.get_db_config()
+        # db_config_dict["emulator_host"] = None # Ensure it's None or not present
+
+        db = SpannerVectorDB(
+            dim=self.DIMENSION,
+            db_config=db_config_dict,
+            db_case_config=self.get_case_config(),
+            collection_name=self.TABLE_NAME,
+            drop_old=False
+        )
+        MockSpannerClient.assert_called_with(project=self.PROJECT_ID)
+        # Restore for other tests if it was globally set
+        if "SPANNER_EMULATOR_HOST" not in os.environ and self.db.emulator_host:
+             os.environ["SPANNER_EMULATOR_HOST"] = self.db.emulator_host
+
+
+    def test_create_table_ddl(self):
+        # This test relies on self.db initialized in setUp,
+        # where table_exists mock returns False initially.
+        # _create_table_if_not_exists is called during SpannerVectorDB.__init__
+        self.mock_database.update_ddl.assert_called_once()
+
+        ddl_statements_list = self.mock_database.update_ddl.call_args[0][0]
+        self.assertEqual(len(ddl_statements_list), 1) # Only CREATE TABLE DDL
+
+        table_ddl = ddl_statements_list[0]
+        self.assertIn(f"CREATE TABLE {self.TABLE_NAME}", table_ddl)
+        self.assertIn(f"embedding ARRAY<FLOAT32>(vector_length={self.DIMENSION}) NOT NULL", table_ddl)
+        self.assertNotIn("NOT_NULLABLE_embedding", table_ddl)
+        self.assertNotIn("CONSTRAINT chk_embedding_dimension", table_ddl)
+        self.assertNotIn("CREATE VECTOR INDEX", table_ddl) # Index creation moved to optimize
+
+    def test_create_table_if_not_exists_already_exists(self):
+        # Simulate table already exists
+        self.mock_snapshot.execute_sql.side_effect = [iter([("sometable",)])] # Table exists
+        self.mock_database.reset_mock() # Reset from setUp's potential call
+
+        # Re-initialize SpannerVectorDB for this specific scenario
+        db = SpannerVectorDB(
+            dim=self.DIMENSION,
+            db_config=self.get_db_config(),
+            db_case_config=self.get_case_config(), # Use default case config
+            collection_name=self.TABLE_NAME,
+            drop_old=False
+        )
+        self.mock_database.update_ddl.assert_not_called() # Should not try to create
+
+    def test_init_drop_old_table_exists(self):
+        # Mock sequence: 1. table_exists (for drop) = True, 2. table_exists (for create) = False
+        self.mock_snapshot.execute_sql.side_effect = [
+            iter([("sometable",)]),  # Table exists for _drop_table
+            iter([])                 # Table does not exist for _create_table_if_not_exists
+        ]
+        self.mock_database.reset_mock()
+        self.mock_database.update_ddl.return_value = self.mock_ddl_operation
+
+        db = SpannerVectorDB(
+            dim=self.DIMENSION,
+            db_config=self.get_db_config(),
+            db_case_config=self.get_case_config(), # Use default case config
+            collection_name=self.TABLE_NAME,
+            drop_old=True
+        )
+
+        self.assertEqual(self.mock_database.update_ddl.call_count, 2)
+
+        # Call 1: DROP TABLE
+        drop_ddl_list = self.mock_database.update_ddl.call_args_list[0][0][0]
+        self.assertEqual(len(drop_ddl_list), 1)
+        self.assertIn(f"DROP TABLE {self.TABLE_NAME}", drop_ddl_list[0])
+
+        # Call 2: CREATE TABLE (only, no index here)
+        create_ddl_list = self.mock_database.update_ddl.call_args_list[1][0][0]
+        self.assertEqual(len(create_ddl_list), 1)
+        self.assertIn(f"CREATE TABLE {self.TABLE_NAME}", create_ddl_list[0])
+        self.assertIn(f"embedding ARRAY<FLOAT32>(vector_length={self.DIMENSION}) NOT NULL", create_ddl_list[0])
+        self.assertNotIn("CREATE VECTOR INDEX", create_ddl_list[0])
+
+
+    def test_optimize_ddl(self):
+        custom_num_leaves = 1234
+        custom_tree_depth = 4
+        case_config = self.get_case_config(num_leaves=custom_num_leaves, tree_depth=custom_tree_depth)
+        self.db.case_config = case_config # Override for this test
+
+        # Reset mock from setUp because __init__ calls _create_table_if_not_exists
+        self.mock_database.reset_mock()
+        self.mock_database.update_ddl.return_value = self.mock_ddl_operation # re-assign
+
+        with self.db.init():
+            self.db.optimize()
+
+        self.assertEqual(self.mock_database.update_ddl.call_count, 2)
+
+        # Call 1: DROP VECTOR INDEX
+        drop_index_ddl_list = self.mock_database.update_ddl.call_args_list[0][0][0]
+        self.assertEqual(len(drop_index_ddl_list), 1)
+        expected_index_name = f"{self.TABLE_NAME}_embedding_approx_idx"
+        self.assertIn(f"DROP VECTOR INDEX IF EXISTS {expected_index_name}", drop_index_ddl_list[0])
+
+        # Call 2: CREATE VECTOR INDEX
+        create_index_ddl_list = self.mock_database.update_ddl.call_args_list[1][0][0]
+        self.assertEqual(len(create_index_ddl_list), 1)
+        create_index_ddl = create_index_ddl_list[0]
+        self.assertIn(f"CREATE VECTOR INDEX {expected_index_name}", create_index_ddl)
+        self.assertIn(f"ON {self.TABLE_NAME}(embedding)", create_index_ddl)
+        self.assertIn(f"OPTIONS (distance_type = 'COSINE', tree_depth = {custom_tree_depth}, num_leaves = {custom_num_leaves})", create_index_ddl)
+
+
+    def test_insert_embeddings(self):
+        embeddings = [[float(i) for i in range(self.DIMENSION)] for _ in range(10)]
+        metadata = [i for i in range(10)]
+
+        # Reset batch mock for specific call verification
+        self.mock_batch.reset_mock()
+
+        with self.db.init(): # Context manager for SpannerVectorDB
+            count, error = self.db.insert_embeddings(embeddings, metadata)
+
+        self.assertEqual(count, 10)
+        self.assertIsNone(error)
+        self.mock_database.batch.assert_called_once()
+        self.mock_batch.insert.assert_called_once_with(
+            table=self.TABLE_NAME,
+            columns=['id', 'embedding'],
+            values=[(metadata[i], embeddings[i]) for i in range(10)]
+        )
+
+    def test_insert_embeddings_empty(self):
+        with self.db.init():
+             count, error = self.db.insert_embeddings([], [])
+        self.assertEqual(count, 0)
+        self.assertIsNone(error)
+        self.mock_batch.insert.assert_not_called()
+
+    def test_insert_embeddings_error(self):
+        self.mock_batch.insert.side_effect = Exception("Spanner Error")
+        embeddings = [[1.0] * self.DIMENSION]
+        metadata = [1]
+
+        with self.db.init():
+            count, error = self.db.insert_embeddings(embeddings, metadata)
+
+        self.assertEqual(count, 0)
+        self.assertIsNotNone(error)
+        self.assertIsInstance(error, Exception)
+
+    def test_search_embedding_approx_cosine_distance(self):
+        query_vector = [0.5] * self.DIMENSION
+        k_val = 7
+        custom_leaves_to_search = 65
+
+        # Override case_config for this specific test instance if needed, or use setUp's default
+        self.db.case_config = self.get_case_config(num_leaves_to_search=custom_leaves_to_search)
+
+        expected_ids = [101, 102, 103]
+        mock_search_results = [(id_val,) for id_val in expected_ids]
+        self.mock_snapshot.execute_sql.return_value = iter(mock_search_results)
+
+        with self.db.init():
+            results = self.db.search_embedding(query_vector, k=k_val)
+
+        self.assertEqual(results, expected_ids)
+
+        expected_sql = f"""
+        SELECT id
+        FROM {self.TABLE_NAME}
+        ORDER BY APPROX_COSINE_DISTANCE(embedding, @query_vector, options => JSON_OBJECT('num_leaves_to_search', @num_leaves_to_search_param))
+        LIMIT @k
+        """
+        # Strip whitespace for robust comparison
+        # self.mock_snapshot.execute_sql.assert_called_once()
+        args, kwargs = self.mock_snapshot.execute_sql.call_args
+        self.assertEqual(args[0].strip(), expected_sql.strip())
+
+        expected_params = {
+            "query_vector": query_vector,
+            "num_leaves_to_search_param": custom_leaves_to_search,
+            "k": k_val
+        }
+        self.assertEqual(kwargs['params'], expected_params)
+
+        expected_param_types = {
+            "query_vector": spanner_v1.param_types.Array(spanner_v1.param_types.FLOAT32),
+            "num_leaves_to_search_param": spanner_v1.param_types.INT64,
+            "k": spanner_v1.param_types.INT64
+        }
+        self.assertEqual(kwargs['param_types'], expected_param_types)
+
+    def test_search_embedding_approx_error(self):
+        self.mock_snapshot.execute_sql.side_effect = Exception("Spanner SQL Error")
+        query_vector = [0.1] * self.DIMENSION
+
+        with self.db.init():
+            results = self.db.search_embedding(query_vector, k=10)
+
+        self.assertEqual(results, [])
+        self.mock_snapshot.execute_sql.assert_called_once() # Ensure it was called
+
+    def test_need_normalize_cosine(self):
+        self.assertFalse(self.db.need_normalize_cosine())
+
+    def test_optimize(self):
+        # Optimize is a no-op, just ensure it runs without error
+        try:
+            with self.db.init():
+                self.db.optimize(data_size=1000)
+        except Exception as e:
+            self.fail(f"optimize() raised an exception: {e}")
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+A quick note on the `setUp` and initialization:
+- I'm patching `spanner_v1.Client` at the class or method level for tests that need to control its instantiation.
+- The `SpannerVectorDB` constructor expects the `db_config` to be a dictionary, which it then uses to create `SpannerConfig`.
+- `collection_name` passed to `SpannerVectorDB` is used as the table name.
+- `SpannerCaseConfig` is passed directly.
+
+There was a slight misunderstanding in my previous plan: `SpannerVectorDB`'s constructor takes `db_config` as a `dict`, not a `SpannerConfig` object directly. The `spanner.py` code confirms this: `self.db_config = SpannerConfig(**db_config)`. I've adjusted the test setup accordingly. Also, `spanner_v1` needs to be imported for `param_types`. I'll add that to the `spanner.py` file.
+
+One more thing, `spanner_v1` is used in `spanner.py` but not imported. I need to fix that in `spanner.py`.

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -48,6 +48,7 @@ class DB(Enum):
     Vespa = "Vespa"
     LanceDB = "LanceDB"
     OceanBase = "OceanBase"
+    SPANNER = "Spanner"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915
@@ -181,6 +182,10 @@ class DB(Enum):
             from .lancedb.lancedb import LanceDB
 
             return LanceDB
+
+        if self == DB.SPANNER:
+            from .spanner.spanner import SpannerVectorDB
+            return SpannerVectorDB
 
         msg = f"Unknown DB: {self.name}"
         raise ValueError(msg)
@@ -318,6 +323,10 @@ class DB(Enum):
 
             return LanceDBConfig
 
+        if self == DB.SPANNER:
+            from .spanner.config import SpannerConfig
+            return SpannerConfig
+
         msg = f"Unknown DB: {self.name}"
         raise ValueError(msg)
 
@@ -429,6 +438,10 @@ class DB(Enum):
             from .lancedb.config import _lancedb_case_config
 
             return _lancedb_case_config.get(index_type)
+
+        if self == DB.SPANNER:
+            from .spanner.config import SpannerCaseConfig
+            return SpannerCaseConfig
 
         # DB.Pinecone, DB.Chroma, DB.Redis
         return EmptyDBCaseConfig

--- a/vectordb_bench/backend/clients/spanner/config.py
+++ b/vectordb_bench/backend/clients/spanner/config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+@dataclass
+class SpannerConfig:
+    project_id: str
+    instance_id: str
+    database_id: str
+    table_name: str = "vector_embeddings"
+    emulator_host: Optional[str] = field(default=None)
+
+from vectordb_bench.backend.clients.api import DBCaseConfig
+
+@dataclass
+class SpannerCaseConfig(DBCaseConfig):
+    num_leaves: int = 1000
+    num_leaves_to_search: int = 100
+    tree_depth: int = 2 # Default value for tree_depth
+
+    # Note: These parameters are intended for use with specific Spanner features
+    # (e.g., vector indexes with OPTIONS, APPROX_COSINE_DISTANCE function)
+    # which might require specific versions or configurations of Spanner.
+
+    def index_param(self) -> dict:
+        return {
+            "num_leaves": self.num_leaves,
+            "tree_depth": self.tree_depth,
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "num_leaves_to_search": self.num_leaves_to_search,
+        }

--- a/vectordb_bench/backend/clients/spanner/spanner.py
+++ b/vectordb_bench/backend/clients/spanner/spanner.py
@@ -1,0 +1,243 @@
+import time
+import os
+from contextlib import contextmanager
+from typing import List, Optional, Tuple
+
+from google.cloud import spanner_v1
+from google.auth.exceptions import DefaultCredentialsError
+from vectordb_bench.backend.clients.api import VectorDB, MetricType, DBCaseConfig
+from vectordb_bench.backend.clients.spanner.config import SpannerConfig, SpannerCaseConfig
+from vectordb_bench.backend.dataset import Dataset
+
+# Attempt to set credentials from environment variable if not already set
+# This is useful for local development or CI environments
+if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ and "SPANNER_EMULATOR_HOST" not in os.environ:
+    # Replace with the actual path to your service account key file if needed
+    # or ensure GOOGLE_APPLICATION_CREDENTIALS is set in your environment.
+    # For emulator, SPANNER_EMULATOR_HOST should be set.
+    print("Warning: GOOGLE_APPLICATION_CREDENTIALS not set and SPANNER_EMULATOR_HOST not set.")
+    print("Spanner client may not be able to authenticate unless running on GCP with default credentials.")
+
+class SpannerVectorDB(VectorDB):
+    def __init__(
+        self,
+        dim: int,
+        db_config: dict,
+        db_case_config: DBCaseConfig,
+        collection_name: str, # This will be used as the table name
+        drop_old: bool = False,
+        **kwargs,
+    ):
+        self.dim = dim
+        self.db_config = SpannerConfig(**db_config)
+        self.case_config: SpannerCaseConfig = db_case_config # Explicitly type hint
+        self.table_name = self.db_config.table_name # Use table_name from SpannerConfig
+        self.project_id = self.db_config.project_id
+        self.instance_id = self.db_config.instance_id
+        self.database_id = self.db_config.database_id
+        self.emulator_host = self.db_config.emulator_host
+
+        self.spanner_client = None
+        self.instance = None
+        self.database = None
+
+        if self.emulator_host:
+            print(f"Using Spanner Emulator: {self.emulator_host}")
+            self.spanner_client = spanner_v1.Client(project=self.project_id, client_options={"api_endpoint": self.emulator_host})
+        else:
+            try:
+                self.spanner_client = spanner_v1.Client(project=self.project_id)
+            except DefaultCredentialsError:
+                print("ERROR: Could not automatically determine credentials. " \
+                      "Please set GOOGLE_APPLICATION_CREDENTIALS or ensure you are running " \
+                      "in an environment with default credentials (e.g., a GCE instance).")
+                raise
+
+        self.instance = self.spanner_client.instance(self.instance_id)
+        self.database = self.instance.database(self.database_id)
+
+        if not self.instance.exists():
+            raise RuntimeError(f"Spanner instance {self.instance_id} does not exist in project {self.project_id}.")
+
+        if not self.database.exists():
+            print(f"Database {self.database_id} does not exist. Creating database...")
+            # DDL for database creation (if needed, though typically pre-exists)
+            # For this benchmark, we assume the database exists or is created outside.
+            # If creation is required, it would involve specific DDL commands.
+            # self.database.create().result() # This is a long-running operation
+            raise RuntimeError(f"Spanner database {self.database_id} does not exist. Please create it first.")
+
+
+        if drop_old:
+            self._drop_table()
+
+        self._create_table_if_not_exists()
+
+    @contextmanager
+    def init(self) -> None:
+        # Spanner client is initialized in __init__
+        # Connection pooling is handled by the client library.
+        # For this context manager, we don't need to do anything specific for setup/teardown per call.
+        # If there were per-call resource acquisition/release, it would go here.
+        try:
+            yield
+        finally:
+            # Client is long-lived, no specific close needed here for each operation set.
+            # If we wanted to close the client after all operations, it would be outside this init.
+            pass
+
+    def _table_exists(self) -> bool:
+        """Checks if the table already exists in the database."""
+        with self.database.snapshot() as snapshot:
+            results = snapshot.execute_sql(
+                f"SELECT table_name FROM information_schema.tables WHERE table_name = '{self.table_name}'"
+            )
+            return any(results)
+
+    def _create_table_if_not_exists(self):
+        if not self._table_exists():
+            print(f"Table {self.table_name} does not exist. Creating table with FLOAT32 embedding column...")
+            # DDL for table creation with embedding column as ARRAY<FLOAT32>(vector_length=dim) NOT NULL
+            table_ddl = f"""CREATE TABLE {self.table_name} (
+                id INT64 NOT NULL,
+                embedding ARRAY<FLOAT32>(vector_length={self.dim}) NOT NULL
+            ) PRIMARY KEY (id)"""
+
+            ddl_statements = [table_ddl]
+
+            print(f"Attempting to execute DDL for table creation: {table_ddl}")
+
+            operation = self.database.update_ddl(ddl_statements)
+            operation.result() # Wait for completion
+            print(f"Table {self.table_name} creation process completed.")
+        else:
+            print(f"Table {self.table_name} already exists.")
+
+
+    def _drop_table(self):
+        if self._table_exists():
+            print(f"Dropping table {self.table_name}...")
+            ddl_statements = [f"DROP TABLE {self.table_name}"]
+            operation = self.database.update_ddl(ddl_statements)
+            operation.result() # Wait for completion
+            print(f"Table {self.table_name} dropped successfully.")
+
+    def insert_embeddings(
+        self,
+        embeddings: List[List[float]],
+        metadata: List[int],
+        **kwargs,
+    ) -> Tuple[int, Optional[Exception]]:
+        if not embeddings:
+            return 0, None
+
+        rows = [(metadata[i], embedding) for i, embedding in enumerate(embeddings)]
+
+        # Define columns for insert
+        columns = ['id', 'embedding']
+
+        try:
+            with self.database.batch() as batch:
+                batch.insert(
+                    table=self.table_name,
+                    columns=columns,
+                    values=rows,
+                )
+            # print(f"Successfully inserted {len(rows)} rows into {self.table_name}.")
+            return len(rows), None
+        except Exception as e:
+            print(f"Error inserting embeddings: {e}")
+            return 0, e
+
+    def search_embedding(
+        self,
+        query: List[float],
+        k: int = 100,
+        filters: Optional[dict] = None,
+    ) -> List[int]:
+        results_list = []
+        num_leaves_to_search_param = self.case_config.search_param()['num_leaves_to_search']
+
+        # Using APPROX_COSINE_DISTANCE with JSON_OBJECT options
+        sql_query = f"""
+        SELECT id
+        FROM {self.table_name}
+        ORDER BY APPROX_COSINE_DISTANCE(embedding, @query_vector, options => JSON_OBJECT('num_leaves_to_search', @num_leaves_to_search_param))
+        LIMIT @k
+        """
+
+        params = {
+            "query_vector": query, # Python list of floats, will be converted by client lib
+            "num_leaves_to_search_param": num_leaves_to_search_param,
+            "k": k
+        }
+        param_types = {
+            "query_vector": spanner_v1.param_types.Array(spanner_v1.param_types.FLOAT32),
+            "num_leaves_to_search_param": spanner_v1.param_types.INT64,
+            "k": spanner_v1.param_types.INT64
+        }
+
+        print(f"Executing APPROX_COSINE_DISTANCE search: {sql_query.strip()}")
+        print(f"Parameters: num_leaves_to_search={num_leaves_to_search_param}, k={k}")
+
+        try:
+            with self.database.snapshot() as snapshot:
+                results = snapshot.execute_sql(sql_query, params=params, param_types=param_types)
+                for row in results:
+                    results_list.append(row[0])
+        except Exception as e:
+            print(f"Error during APPROX_COSINE_DISTANCE search: {e}")
+            return [] # Return empty if search fails
+
+        return results_list
+
+    def optimize(self, data_size: Optional[int] = None, **kwargs):
+        index_name = f"{self.table_name}_embedding_approx_idx" # Consistent index name
+        index_params = self.case_config.index_param()
+        num_leaves_val = index_params.get('num_leaves')
+        tree_depth_val = index_params.get('tree_depth')
+
+        # Drop the index if it exists
+        drop_ddl = f"DROP VECTOR INDEX IF EXISTS {index_name}"
+        print(f"Attempting to drop vector index (if exists): {drop_ddl}")
+        try:
+            drop_op = self.database.update_ddl([drop_ddl])
+            drop_op.result(timeout=3600) # Wait for completion, potentially long
+            print(f"Vector index {index_name} dropped or did not exist.")
+        except Exception as e:
+            # Log error during drop, but proceed to create, as "IF EXISTS" should handle non-existence for some errors.
+            # However, other errors (permissions, DDL structure for specific Spanner versions) could occur.
+            print(f"Warning: Error encountered during DROP VECTOR INDEX IF EXISTS: {e}. Attempting creation.")
+
+        # Create the vector index
+        # Note: DDL uses `distance_type`, `tree_depth`, `num_leaves` as per the latest request.
+        create_ddl = f"""CREATE VECTOR INDEX {index_name}
+                       ON {self.table_name}(embedding)
+                       OPTIONS (distance_type = 'COSINE', tree_depth = {tree_depth_val}, num_leaves = {num_leaves_val})"""
+
+        print(f"Attempting to create vector index: {create_ddl}")
+        try:
+            create_op = self.database.update_ddl([create_ddl])
+            create_op.result(timeout=3600) # Wait for completion, potentially very long operation
+            print(f"Vector index {index_name} creation process completed.")
+        except Exception as e_create: # Changed variable name to avoid conflict
+            print(f"Error creating vector index {index_name}: {e_create}")
+            raise # Re-raise the exception as index creation is critical
+
+    def need_normalize_cosine(self) -> bool:
+        # Spanner's COSINE_DISTANCE function works correctly with unnormalized vectors.
+        # It calculates 1 - (cosine_similarity).
+        # So, no explicit normalization is required by the client *for the distance function itself*.
+        return False
+
+    # Helper or additional methods can be added here if necessary
+    def __del__(self):
+        # Proper cleanup of resources if any were not handled by context managers
+        # The Spanner client itself doesn't have an explicit close() method in the same way
+        # some other DB clients do. It manages connections internally.
+        # If we had created specific sessions or transactions that needed explicit closing
+        # outside of a 'with' block, this would be the place.
+        # For now, relying on Python's garbage collection for the client object.
+        pass
+
+```

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1788,4 +1788,8 @@ CASE_CONFIG_MAP = {
         CaseLabel.Load: AWSOpensearchLoadingConfig,
         CaseLabel.Performance: AWSOpenSearchPerformanceConfig,
     },
+    DB.SPANNER: {
+        CaseLabel.Load: [],
+        CaseLabel.Performance: [],
+    },
 }


### PR DESCRIPTION
fix: Align Spanner vector search with GCP documentation

This commit revises the Cloud Spanner integration for vector search to accurately reflect current GCP documentation for Approximate Nearest Neighbor (ANN) search.

Key changes:

- Updated `SpannerCaseConfig`:
    - Removed outdated/placeholder ScaNN parameters.
    - Added `tree_depth` parameter for vector index configuration.
    - `index_param()` now returns `num_leaves` and `tree_depth`.
    - `search_param()` now returns `num_leaves_to_search`.

- Updated `SpannerVectorDB`:
    - Embedding column type changed to `ARRAY<FLOAT32>(vector_length=DIM) NOT NULL`.
    - Removed helper `NOT_NULLABLE_embedding` column.
    - Vector index creation (`CREATE VECTOR INDEX ... OPTIONS (...)`) is now performed in the `optimize()` method, not during initial table creation. This aligns with best practices for building the index on a populated table.
    - Search functionality (`search_embedding`) now uses the `APPROX_COSINE_DISTANCE` function directly in the `ORDER BY` clause with the `options => JSON_OBJECT('num_leaves_to_search', ...)` parameter, as per documentation.
    - Removed usage of the (incorrect for this context) `spanner.vector_find_neighbors` function and the previous fallback logic.

- Unit tests in `tests/test_spanner.py` have been updated to mock and verify the new DDL statements for table and vector index creation, the updated `SpannerCaseConfig`, and the revised search query structure.